### PR TITLE
Update AVR instruction set manual url

### DIFF
--- a/AVR_SUPPORT.md
+++ b/AVR_SUPPORT.md
@@ -1,6 +1,6 @@
 # Supported Instructions
 
-Here is a working list of the assembly instructions to be implemented and whether we have a test case to handle each. For those interested in either implementing instructions or writing test cases, refer to [Atmel's AVR Instruction Set](http://www.atmel.com/images/doc0856.pdf) for documentation on each instruction.
+Here is a working list of the assembly instructions to be implemented and whether we have a test case to handle each. For those interested in either implementing instructions or writing test cases, refer to [Atmel's AVR Instruction Set](http://www.atmel.com/images/atmel-0856-avr-instruction-set-manual.pdf) for documentation on each instruction.
 
 ## Testing your work
 


### PR DESCRIPTION
This version is newer than the previously linked.